### PR TITLE
feat: add router extension and export axum

### DIFF
--- a/examples/leaderboard.rs
+++ b/examples/leaderboard.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use jiff::Zoned;
+use job_watcher::axum::{Router, extract::State, routing::get};
 use job_watcher::{
     AppBuilder, Heartbeat, TaskLabel, WatchedTask, WatchedTaskOutput, WatcherAppContext,
     config::{Delay, TaskConfig, WatcherConfig},
@@ -83,6 +84,24 @@ impl WatcherAppContext for DummyApp {
     fn title(&self) -> String {
         "Example application Status".to_owned()
     }
+
+    fn extend_router<S>(&self, router: Router<S>) -> Router<S>
+    where
+        S: Clone + Send + Sync + 'static,
+    {
+        let custom_router = Router::new()
+            .route("/", get(hello_handler))
+            .with_state(HelloState(self.0.clone()));
+
+        router.nest_service("/hello", custom_router)
+    }
+}
+
+#[derive(Clone)]
+struct HelloState(Zoned);
+
+async fn hello_handler(State(state): State<HelloState>) -> String {
+    format!("Hello from custom route! App live since {}", state.0)
 }
 
 impl WatchedTask<DummyApp> for LeaderBoard {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,17 +13,24 @@ pub enum Delay {
 #[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TaskConfig {
-    /// Delay between runs
+    /// Delay between successful task executions.
     pub delay: Delay,
-    /// How many seconds before we should consider the result out of date
+    /// Number of seconds a task can run before it is considered "out of date".
     ///
-    /// This does not include the delay time
+    /// If a task's execution time exceeds this value, its status will be flagged
+    /// accordingly. This is useful for monitoring tasks that might be stuck.
+    ///
+    /// Setting this also enables a hard timeout on task execution. If a task
+    /// runs for longer than `MAX_TASK_SECONDS` (180 seconds), it will be
+    /// cancelled.
     pub out_of_date: Option<u32>,
-    /// How many times to retry before giving up, overriding the general watcher
-    /// config
+    /// Number of times to retry a failing task before giving up.
+    ///
+    /// This overrides the global `retries` setting in `WatcherConfig`.
     pub retries: Option<usize>,
-    /// How many seconds to delay between retries, overriding the general
-    /// watcher config
+    /// Delay in seconds between retries of a failing task.
+    ///
+    /// This overrides the global `delay_between_retries` setting in `WatcherConfig`.
     pub delay_between_retries: Option<u32>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use crate::defaults;
 use std::collections::HashMap;
 
 #[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug)]
@@ -38,20 +37,17 @@ pub struct TaskConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct WatcherConfig {
     /// How many times to retry before giving up
-    #[serde(default = "defaults::retries")]
     pub retries: usize,
     /// How many seconds to delay between retries
-    #[serde(default = "defaults::delay_between_retries")]
     pub delay_between_retries: u32,
-    #[serde(default)]
     pub tasks: HashMap<String, TaskConfig>,
 }
 
 impl Default for WatcherConfig {
     fn default() -> Self {
         Self {
-            retries: defaults::retries(),
-            delay_between_retries: defaults::delay_between_retries(),
+            retries: 6,
+            delay_between_retries: 20,
             tasks: Default::default(),
         }
     }

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,7 +1,0 @@
-pub(super) fn retries() -> usize {
-    6
-}
-
-pub(super) fn delay_between_retries() -> u32 {
-    20
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 mod rest_api;
 
 pub mod config;
-mod defaults;
 
 use anyhow::{Context, Result};
+pub use axum;
 use axum::{
     Json,
     http::{self, HeaderValue},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ pub trait WatcherAppContext {
     fn watcher_config(&self) -> WatcherConfig;
     fn triggers_alert(&self, label: &TaskLabel, selected_label: Option<&TaskLabel>) -> bool;
     fn show_output(&self, label: &TaskLabel) -> bool;
+    fn extend_router<S>(&self, router: axum::Router<S>) -> axum::Router<S>
+    where
+        S: Clone + Send + Sync + 'static,
+    {
+        router
+    }
 }
 
 #[derive(

--- a/src/rest_api.rs
+++ b/src/rest_api.rs
@@ -1,9 +1,9 @@
-use std::{convert::Infallible, sync::Arc};
+use std::{convert::Infallible, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::{
     extract::{Path, State},
-    http::{self, HeaderMap, header},
+    http::{self, HeaderMap, StatusCode, header},
     response::IntoResponse,
     routing::get,
 };
@@ -12,6 +12,7 @@ use tower::ServiceBuilder;
 use tower_http::{
     cors::CorsLayer,
     limit::RequestBodyLimitLayer,
+    timeout::TimeoutLayer,
     trace::{self, TraceLayer},
 };
 use tracing::Level;
@@ -40,9 +41,10 @@ pub(crate) async fn start_rest_api<C: WatcherAppContext + Send + Sync + Clone + 
                 .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
         )
         .layer(RequestBodyLimitLayer::new(1_024_000))
-        // .layer(TimeoutLayer::new(std::time::Duration::from_secs(
-        //     5
-        // )))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(3),
+        ))
         .layer(
             CorsLayer::new()
                 .allow_origin(tower_http::cors::Any)

--- a/src/rest_api.rs
+++ b/src/rest_api.rs
@@ -60,12 +60,10 @@ pub(crate) async fn start_rest_api<C: WatcherAppContext + Send + Sync + Clone + 
 
     let router = app.extend_router(router);
 
-    let router = router
-        .layer(service_builder)
-        .with_state(RestApp {
-            app: app.clone(),
-            statuses,
-        });
+    let router = router.layer(service_builder).with_state(RestApp {
+        app: app.clone(),
+        statuses,
+    });
 
     tracing::info!("Launching server");
 

--- a/src/rest_api.rs
+++ b/src/rest_api.rs
@@ -56,9 +56,16 @@ pub(crate) async fn start_rest_api<C: WatcherAppContext + Send + Sync + Clone + 
         .route("/", get(homepage))
         .route("/healthz", get(healthz))
         .route("/status/{*label}", get(status::single))
-        .route("/status", get(status::all))
+        .route("/status", get(status::all));
+
+    let router = app.extend_router(router);
+
+    let router = router
         .layer(service_builder)
-        .with_state(RestApp { app, statuses });
+        .with_state(RestApp {
+            app: app.clone(),
+            statuses,
+        });
 
     tracing::info!("Launching server");
 


### PR DESCRIPTION
Expose the Axum crate and allow router extensions through the WatcherAppContext trait. This allows developers to define custom API endpoints and state while maintaining version compatibility with the underlying web server.

Simplify internal configuration logic by removing the defaults module. Define default values for retries and delays directly within the WatcherConfig structure and update the example to demonstrate custom routing.