### PR TITLE
refactor: use Url type for Slack webhooks

### DIFF
--- a/examples/leaderboard.rs
+++ b/examples/leaderboard.rs
@@ -90,8 +90,11 @@ impl WatcherAppContext for DummyApp {
     }
 
     fn notifier_config(&self) -> Option<job_watcher::NotifierConfig> {
-        let webhook = std::env::var("HEALTH_CHECK_SLACK_WEBHOOK").ok();
-        webhook.map(|hook| job_watcher::NotifierConfig::Slack(SlackConfig { webhook_url: hook }))
+        let webhook_str = std::env::var("HEALTH_CHECK_SLACK_WEBHOOK").ok()?;
+        let hook = webhook_str.parse().ok()?;
+        Some(job_watcher::NotifierConfig::Slack(SlackConfig {
+            webhook_url: hook,
+        }))
     }
 
     fn extend_router<S>(&self, router: Router<S>) -> Router<S>

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde_json::json;
 
 use crate::{Alert, TaskLabel, WatcherAppContext};
 
 #[derive(Clone, Debug)]
 pub struct SlackConfig {
-    pub webhook_url: String,
+    pub webhook_url: Url,
 }
 
 impl SlackConfig {
@@ -97,7 +97,7 @@ impl SlackConfig {
         });
 
         client
-            .post(&self.webhook_url)
+            .post(self.webhook_url.clone())
             .json(&payload)
             .send()
             .await?
@@ -176,7 +176,7 @@ impl SlackConfig {
         });
 
         client
-            .post(&self.webhook_url)
+            .post(self.webhook_url.clone())
             .json(&payload)
             .send()
             .await?


### PR DESCRIPTION
Replace the raw String representation of Slack webhooks with a strongly-typed reqwest::Url. Found this while updating this dependency for Satoshi project.